### PR TITLE
Add large-v3

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -29,7 +29,7 @@ class Predictor(BasePredictor):
     def setup(self):
         """Loads whisper models into memory to make running multiple predictions efficient"""
 
-        with open(f"./weights/large-v2.pt", "rb") as fp:
+        with open(f"./weights/large-v3.pt", "rb") as fp:
             checkpoint = torch.load(fp, map_location="cpu")
             dims = ModelDimensions(**checkpoint["dims"])
             self.model = Whisper(dims)
@@ -40,8 +40,8 @@ class Predictor(BasePredictor):
         self,
         audio: Path = Input(description="Audio file"),
         model: str = Input(
-            default="large-v2",
-            choices=["large", "large-v2"],
+            default="large-v3",
+            choices=["large", "large-v3"],
             description="Choose a Whisper model.",
         ),
         transcription: str = Input(

--- a/scripts/get_weights.sh
+++ b/scripts/get_weights.sh
@@ -6,4 +6,5 @@ mkdir -p weights
 # curl -o weights/small.pt -L https://openaipublic.azureedge.net/main/whisper/models/9ecf779972d90ba49c06d968637d720dd632c55bbf19d441fb42bf17a411e794/small.pt
 # curl -o weights/medium.pt -L https://openaipublic.azureedge.net/main/whisper/models/345ae4da62f9b3d59415adc60127b97c714f32e89e936602e85993674d08dcb1/medium.pt
 # curl -o weights/large-v1.pt -L https://openaipublic.azureedge.net/main/whisper/models/e4b87e7e0bf463eb8e6956e646f1e277e901512310def2c24bf0e11bd3c28e9a/large-v1.pt
-curl -o weights/large-v2.pt -L https://openaipublic.azureedge.net/main/whisper/models/81f7c96c852ee8fc832187b0132e569d6c3065a3252ed18e56effd0b6a73e524/large-v2.pt
+# curl -o weights/large-v2.pt -L https://openaipublic.azureedge.net/main/whisper/models/81f7c96c852ee8fc832187b0132e569d6c3065a3252ed18e56effd0b6a73e524/large-v2.pt
+curl -o weights/large-v3.pt -L https://openaipublic.azureedge.net/main/whisper/models/e5b1a55b89c1367dacf97e3e19bfd829a01529dbfdeefa8caeb59b3f1b81dadb/large-v3.pt


### PR DESCRIPTION
Attempt at updating to large-v3. 
Got the large-v3 weights [link from here](https://github.com/ggerganov/whisper.cpp/issues/1437)
However when testing I kept getting the following error:

> RuntimeError: Given groups=1, weight of size [1280, 128, 3], expected input[1, 80, 3000] to have 128 channels, but got 80 channels instead