### PR TITLE
Feature/lazy loading and updates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 .git
+/weights/

--- a/cog.yaml
+++ b/cog.yaml
@@ -10,17 +10,22 @@ build:
     - "ffmpeg"
 
   # python version in the form '3.8' or '3.8.12'
-  python_version: "3.9"
+  python_version: "3.11"
 
   # a list of packages in the format <package-name>==<version>
   python_packages:
     - "numpy==1.23.5"
-    - "torch==1.13.0"
-    - "tqdm==4.64.1"
-    - "more-itertools==9.0.0"
-    - "transformers==4.25.1"
+    - "torch==2.0.1"
+    - "tqdm==4.66.1"
+    - "more-itertools==10.1.0"
+    - "transformers==4.35.0"
     - "ffmpeg-python==0.2.0"
-    - "openai-whisper==20230308"
+    - "openai-whisper==20231106"
+    - ipython
+
+  # commands run after the environment is setup
+  run:
+    - curl -o /usr/local/bin/pget -L "https://github.com/replicate/pget/releases/download/v0.8.2/pget_linux_x86_64" && chmod +x /usr/local/bin/pget
 
 # predict.py defines how predictions are run on your model
 predict: "predict.py:Predictor"

--- a/predict.py
+++ b/predict.py
@@ -75,10 +75,17 @@ class Predictor(BasePredictor):
     def predict(
         self,
         audio: Path = Input(description="Audio file"),
+        # Note: We only serve the large-v3 model to reduce switching costs and because it meets most users' needs.
+        # Other model sizes (base, small, tiny) are commented out as they're not currently offered.
         model: str = Input(
-            choices=["tiny", "base", "small", "large-v3"],
+            choices=[
+                "large-v3",
+                # "base",
+                # "small",
+                # "tiny",
+            ],
             default="large-v3",
-            description="Choose the Whisper model size.",
+            description="Whisper model size (currently only large-v3 is supported).",
         ),
         transcription: str = Input(
             choices=["plain text", "srt", "vtt"],

--- a/predict.py
+++ b/predict.py
@@ -1,19 +1,17 @@
-import io
-import os
 from typing import Optional, Any
+import os
+import time
+import subprocess
 import torch
 import numpy as np
-import cProfile
-import pstats
-from pstats import SortKey
-import time
 
 from cog import BasePredictor, Input, Path, BaseModel
-
-import whisper
 from whisper.model import Whisper, ModelDimensions
 from whisper.tokenizer import LANGUAGES, TO_LANGUAGE_CODE
 from whisper.utils import format_timestamp
+
+MODEL_CACHE = "weights"
+BASE_URL = f"https://weights.replicate.delivery/default/whisper-v3/{MODEL_CACHE}/"
 
 
 class ModelOutput(BaseModel):
@@ -25,24 +23,62 @@ class ModelOutput(BaseModel):
     srt_file: Optional[Path]
 
 
+def download_weights(url: str, dest: str) -> None:
+    start = time.time()
+    print("[!] Initiating download from URL: ", url)
+    print("[~] Destination path: ", dest)
+    if ".tar" in dest:
+        dest = os.path.dirname(dest)
+    command = ["pget", "-vf" + ("x" if ".tar" in url else ""), url, dest]
+    try:
+        print(f"[~] Running command: {' '.join(command)}")
+        subprocess.check_call(command, close_fds=False)
+    except subprocess.CalledProcessError as e:
+        print(
+            f"[ERROR] Failed to download weights. Command '{' '.join(e.cmd)}' returned non-zero exit status {e.returncode}."
+        )
+        raise
+    print("[+] Download completed in: ", time.time() - start, "seconds")
+
+
 class Predictor(BasePredictor):
     def setup(self):
-        """Loads whisper models into memory to make running multiple predictions efficient"""
+        """Load the large-v3 model"""
+        self.model_cache = MODEL_CACHE
+        self.models = {}
+        self.current_model = "large-v3"
+        self.load_model("large-v3")
 
-        with open(f"./weights/large-v2.pt", "rb") as fp:
-            checkpoint = torch.load(fp, map_location="cpu")
-            dims = ModelDimensions(**checkpoint["dims"])
-            self.model = Whisper(dims)
-            self.model.load_state_dict(checkpoint["model_state_dict"])
-            self.model.to("cuda")
+    def load_model(self, model_name):
+        if model_name not in self.models:
+            if not os.path.exists(self.model_cache):
+                os.makedirs(self.model_cache)
+
+            model_file = f"{model_name}.pt"
+            url = BASE_URL + model_file
+            dest_path = os.path.join(self.model_cache, model_file)
+
+            if not os.path.exists(dest_path):
+                download_weights(url, dest_path)
+
+            with open(dest_path, "rb") as fp:
+                checkpoint = torch.load(fp, map_location="cpu")
+                dims = ModelDimensions(**checkpoint["dims"])
+                model = Whisper(dims)
+                model.load_state_dict(checkpoint["model_state_dict"])
+                model.to("cuda")
+
+            self.models[model_name] = model
+        self.current_model = model_name
+        return self.models[model_name]
 
     def predict(
         self,
         audio: Path = Input(description="Audio file"),
         model: str = Input(
-            default="large-v2",
-            choices=["large", "large-v2"],
-            description="Choose a Whisper model.",
+            choices=["tiny", "base", "small", "large-v3"],
+            default="large-v3",
+            description="Choose the Whisper model size.",
         ),
         transcription: str = Input(
             choices=["plain text", "srt", "vtt"],
@@ -54,10 +90,11 @@ class Predictor(BasePredictor):
             description="Translate the text to English when set to True",
         ),
         language: str = Input(
-            choices=sorted(LANGUAGES.keys())
+            choices=["auto"]
+            + sorted(LANGUAGES.keys())
             + sorted([k.title() for k in TO_LANGUAGE_CODE.keys()]),
-            default=None,
-            description="language spoken in the audio, specify None to perform language detection",
+            default="auto",
+            description="Language spoken in the audio, specify 'auto' for automatic language detection",
         ),
         temperature: float = Input(
             default=0,
@@ -94,11 +131,16 @@ class Predictor(BasePredictor):
         no_speech_threshold: float = Input(
             default=0.6,
             description="if the probability of the <|nospeech|> token is higher than this value AND the decoding has failed due to `logprob_threshold`, consider the segment as silence",
-        )    
+        ),
     ) -> ModelOutput:
         """Transcribes and optionally translates a single audio file"""
-        print(f"Transcribe with {model} model")
-        model = self.model
+        print(f"Transcribe with {model} model.")
+
+        if model != self.current_model:
+            self.model = self.load_model(model)
+        else:
+            self.model = self.models[self.current_model]
+
         if temperature_increment_on_fallback is not None:
             temperature = tuple(
                 np.arange(temperature, 1.0 + 1e-6, temperature_increment_on_fallback)
@@ -106,6 +148,7 @@ class Predictor(BasePredictor):
         else:
             temperature = [temperature]
 
+        language = None if language.lower() == "auto" else language
         args = {
             "language": language,
             "patience": patience,
@@ -116,10 +159,10 @@ class Predictor(BasePredictor):
             "logprob_threshold": logprob_threshold,
             "no_speech_threshold": no_speech_threshold,
             "fp16": True,
-            "verbose": False
+            "verbose": False,
         }
         with torch.inference_mode():
-            result = model.transcribe(str(audio), temperature=temperature, **args)
+            result = self.model.transcribe(str(audio), temperature=temperature, **args)
 
         if transcription == "plain text":
             transcription = result["text"]
@@ -129,7 +172,7 @@ class Predictor(BasePredictor):
             transcription = write_vtt(result["segments"])
 
         if translate:
-            translation = model.transcribe(
+            translation = self.model.transcribe(
                 str(audio), task="translate", temperature=temperature, **args
             )
 

--- a/scripts/get_weights.sh
+++ b/scripts/get_weights.sh
@@ -6,4 +6,5 @@ mkdir -p weights
 # curl -o weights/small.pt -L https://openaipublic.azureedge.net/main/whisper/models/9ecf779972d90ba49c06d968637d720dd632c55bbf19d441fb42bf17a411e794/small.pt
 # curl -o weights/medium.pt -L https://openaipublic.azureedge.net/main/whisper/models/345ae4da62f9b3d59415adc60127b97c714f32e89e936602e85993674d08dcb1/medium.pt
 # curl -o weights/large-v1.pt -L https://openaipublic.azureedge.net/main/whisper/models/e4b87e7e0bf463eb8e6956e646f1e277e901512310def2c24bf0e11bd3c28e9a/large-v1.pt
-curl -o weights/large-v2.pt -L https://openaipublic.azureedge.net/main/whisper/models/81f7c96c852ee8fc832187b0132e569d6c3065a3252ed18e56effd0b6a73e524/large-v2.pt
+# curl -o weights/large-v2.pt -L https://openaipublic.azureedge.net/main/whisper/models/81f7c96c852ee8fc832187b0132e569d6c3065a3252ed18e56effd0b6a73e524/large-v2.pt
+curl -o weights/large-v3.pt -L https://openaipublic.azureedge.net/main/whisper/models/e5b1a55b89c1367dacf97e3e19bfd829a01529dbfdeefa8caeb59b3f1b81dadb/large-v3.pt


### PR DESCRIPTION
This model now has lazy loading, allowing us to switch between large-v3, base, small, and tiny (all downloaded via pget). It assumes large-v3 will always be used, so that will always be loaded on a cold boot.

I've updated the code to match what was actually in the container [r8.im/openai/whisper](http://r8.im/openai/whisper).

I've added a new language setting called "auto". It functions the same as the old setting, i.e. when language was None, it would automatically detect the language in the audio clip.

TLDR:
- Lazy loading for multiple models
- Synchronised with container, added "auto" language
- GitHub permissions/UI bug?

Dan then said:
> [@sakib](https://replicatehq.slack.com/team/U05PVM0QYSK) you (and the rest of the models team) should have push access now. The one change I'd make to your changes is somewhat counterintuitive - I'd remove the model options and only serve large-v3. There's a decent switching cost we incur every time we change models with this Whisper implementation (or at least there was last I checked), and most users are fine with the large-v3 model (I think this was like 90% of requests for the last Whisper that supported different sizes).

Consequently, the lazy loading code is still present, but the model only loads 'large-v3', and that's the only option it has for 'model'.

I've retained the 'model' parameter to match the API input schema, ensuring that nothing should (probably) break.