### PR TITLE
Bug Fix: Handle Missing Duration in .webm Audio Files

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -207,7 +207,7 @@ def get_audio_duration(file_path):
     try:
         probe = ffmpeg.probe(file_path)
         audio_stream = next((stream for stream in probe['streams'] if stream['codec_type'] == 'audio'), None)
-        if audio_stream:
+        if audio_stream and 'duration' in audio_stream:
             duration = float(audio_stream['duration'])
             return np.round(duration)
         else:


### PR DESCRIPTION
The current implementation of the get_audio_duration function encounters a bug when processing .webm audio files. This is due to the absence of duration information in the audio stream metadata, as observed both in our code and the results from the Replicate website below.

To address this issue, I propose an enhancement to the function that includes a check to verify the presence of "duration" information in the audio_stream before attempting to retrieve the duration value.

![image](https://github.com/user-attachments/assets/2a406161-fdf4-4a97-bf2d-de50de70cd3f)
![image](https://github.com/user-attachments/assets/eb66eb0f-8aa6-4577-a53f-f8f2dece96b3)
